### PR TITLE
Add ability to pass custom options when registering source and add option to ignore specific filetypes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,24 @@ You can enable nvim_lua completion via `lua require'compe_nvim_lua'.attach()`.
 You can enable vim-lamp completion via `call compe_lamp#source#attach()`.
 
 #### buffer
-You can enable buffer completion via `lua require'compe':register_lua_source('buffer', require'compe_buffer')`.
+You can enable buffer completion via `lua require'compe':register_lua_source('buffer', require'compe_buffer', opts)`.
+
+[opts](https://github.com/hrsh7th/nvim-compe/wiki#get_metadata)
 
 #### path
-You can enable path completion via `call compe#source#vim_bridge#register('path', compe_path#source#create())`.
+You can enable path completion via `call compe#source#vim_bridge#register('path', compe_path#source#create(), opts)`.
+
+[opts](https://github.com/hrsh7th/nvim-compe/wiki#get_metadata)
 
 #### tags
-You can enable tags completion via `call compe#source#vim_bridge#register('tags', compe_tags#source#create())`.
+You can enable tags completion via `call compe#source#vim_bridge#register('tags', compe_tags#source#create(), opts)`.
+
+[opts](https://github.com/hrsh7th/nvim-compe/wiki#get_metadata)
 
 #### vsnip
-You can enable vsnip completion via `call compe#source#vim_bridge#register('vsnip', compe_vsnip#source#create())`.
+You can enable vsnip completion via `call compe#source#vim_bridge#register('vsnip', compe_vsnip#source#create(), opts)`.
+
+[opts](https://github.com/hrsh7th/nvim-compe/wiki#get_metadata)
 
 
 # Development

--- a/autoload/compe/source/vim_bridge.vim
+++ b/autoload/compe/source/vim_bridge.vim
@@ -4,11 +4,12 @@ let s:sources = {}
 "
 " compe#source#vim_bridge#register
 "
-function! compe#source#vim_bridge#register(id, source) abort
+function! compe#source#vim_bridge#register(id, source, ...) abort
   let s:source_id += 1
   let l:id = a:id . '_' . s:source_id
   let s:sources[l:id] = a:source
-  call luaeval('require"compe":register_vim_source(_A[1])', [l:id])
+  let l:opts = get(a:, 1, {})
+  call luaeval('require"compe":register_vim_source(_A[1], _A[2])', [l:id, l:opts])
   return l:id
 endfunction
 

--- a/lua/compe/completion/source.lua
+++ b/lua/compe/completion/source.lua
@@ -4,11 +4,12 @@ local Context = require'compe.completion.context'
 local Source =  {}
 
 --- new
-function Source.new(id, source)
+function Source.new(id, source, opts)
   local self = setmetatable({}, { __index = Source })
   self.id = id
   self.source = source
   self.context = Context.new({})
+  self.opts = opts or {}
   self:clear()
   return self
 end
@@ -55,6 +56,12 @@ function Source.trigger(self, context, callback)
   -- Check filetypes.
   if metadata.filetypes and #metadata.filetypes then
     if not vim.tbl_contains(metadata.filetypes or {}, context.filetype) then
+      return self:clear()
+    end
+  end
+
+  if metadata.ignored_filetypes and #metadata.ignored_filetypes then
+    if vim.tbl_contains(metadata.ignored_filetypes or {}, context.filetype) then
       return self:clear()
     end
   end
@@ -154,7 +161,7 @@ end
 
 --- get_metadata
 function Source.get_metadata(self)
-  return vim.tbl_extend('keep', self.source:get_metadata(), {
+  return vim.tbl_extend('keep', self.opts, self.source:get_metadata(), {
     sort = true;
     priority = 0;
   })

--- a/lua/compe/init.lua
+++ b/lua/compe/init.lua
@@ -13,13 +13,13 @@ function Compe.new()
 end
 
 --- register_lua_source
-function Compe.register_lua_source(self, id, source)
-  self.completion:register_source(Source.new(id, source))
+function Compe.register_lua_source(self, id, source, opts)
+  self.completion:register_source(Source.new(id, source, opts))
 end
 
 --- register_vim_source
-function Compe.register_vim_source(self, id)
-  self.completion:register_source(Source.new(id, VimBridge.new(id)))
+function Compe.register_vim_source(self, id, opts)
+  self.completion:register_source(Source.new(id, VimBridge.new(id), opts))
 end
 
 --- unregister_source


### PR DESCRIPTION
This PR adds 2 functionalities:

1. Ability to pass options when registering a source. It is appended to metadata.
2. `ignored_filetypes` option that ignores a source for specific filetypes.

I'll add `ignored_filetypes` to wiki once this is merged.