### PR TITLE
WIP: add border to documentation.

### DIFF
--- a/autoload/compe/documentation.vim
+++ b/autoload/compe/documentation.vim
@@ -2,6 +2,7 @@ let s:MarkupContent = vital#compe#import('VS.LSP.MarkupContent')
 let s:FloatingWindow = vital#compe#import('VS.Vim.Window.FloatingWindow')
 
 let s:window = s:FloatingWindow.new()
+let s:border = s:FloatingWindow.new()
 
 "
 " compe#documentation#show
@@ -15,6 +16,7 @@ function! compe#documentation#open(document) abort
 
   let l:pos = s:get_screenpos(pum_getpos(), l:document)
   if empty(l:pos)
+    call s:border.close()
     return s:window.close()
   endif
 
@@ -26,6 +28,24 @@ function! compe#documentation#open(document) abort
   \   'filetype': 'markdown',
   \   'contents': l:document,
   \ })
+
+  let l:width = float2nr(&columns * 0.4)
+  let l:height = float2nr(&lines * 0.4)
+  let l:top = '╭' . repeat('─', l:width - 2) . '╮'
+  let l:mid = '│' . repeat(' ', l:width - 2) . '│'
+  let l:bot = '╰' . repeat('─', l:width - 2) . '╯'
+  let l:lines = [l:top] + repeat([l:mid], l:height - 2) + [l:bot]
+
+
+  call s:border.open({
+  \   'row': l:pos[0],
+  \   'col': l:pos[1],
+  \   'maxwidth': l:width,
+  \   'maxheight': l:height,
+  \   'filetype': 'markdown',
+  \   'contents': l:lines,
+  \ })
+
 endfunction
 
 "
@@ -33,6 +53,7 @@ endfunction
 "
 function! compe#documentation#close() abort
   call s:window.close()
+  call s:border.close()
 endfunction
 
 "
@@ -67,4 +88,6 @@ function! s:get_screenpos(event, document) abort
 
   return [a:event.row, l:col]
 endfunction
+
+
 


### PR DESCRIPTION
Trying to add border to documentation window. Something is wrong with sizing. but it works as expected.

The background highlight of the popup can be adjusted via `vim.api.nvim_win_set_option` with win ids and setting `winhl` to a highlight, e.g. "NormalFloat:Normal". I think this need to be optional after fixing the sizing.

Also I noticed that the window get created and destroyed on each item. It might be a good idea to update the buffer content instead via setlines and using buffer ID. 

![26-12-2020-00:43:53](https://user-images.githubusercontent.com/65782666/103142545-d77b4f00-4715-11eb-9b7a-3d0640d3dbb0.png)

