### PR TITLE
Implement border

### DIFF
--- a/autoload/compe/documentation.vim
+++ b/autoload/compe/documentation.vim
@@ -43,7 +43,7 @@ function! compe#documentation#open(document) abort
   \   'col': l:layout.col,
   \   'maxwidth': l:maxwidth,
   \   'maxheight': l:maxheight,
-  \   'filetype': '',
+  \   'filetype': 'border',
   \   'contents': l:borders,
   \   'winhl': 'NormalFloat:Normal',
   \ })

--- a/autoload/compe/documentation.vim
+++ b/autoload/compe/documentation.vim
@@ -2,36 +2,59 @@ let s:MarkupContent = vital#compe#import('VS.LSP.MarkupContent')
 let s:FloatingWindow = vital#compe#import('VS.Vim.Window.FloatingWindow')
 
 let s:window = s:FloatingWindow.new()
+let s:border = s:FloatingWindow.new()
 
 "
 " compe#documentation#show
 "
 function! compe#documentation#open(document) abort
+  call compe#documentation#close()
   if !compe#_is_selected_manually()
     return
   endif
 
   let l:document = split(s:MarkupContent.normalize(a:document), "\n", v:true)
-
-  let l:pos = s:get_screenpos(pum_getpos(), l:document)
-  if empty(l:pos)
-    return s:window.close()
+  let l:layout = s:get_screenpos(pum_getpos(), l:document)
+  if empty(l:layout)
+    return
   endif
 
+  let l:maxwidth = float2nr(&columns * 0.4)
+  let l:maxheight = float2nr(&lines * 0.4)
+
   call s:window.open({
-  \   'row': l:pos[0],
-  \   'col': l:pos[1],
-  \   'maxwidth': float2nr(&columns * 0.4),
-  \   'maxheight': float2nr(&lines * 0.4),
+  \   'row': l:layout.row + 1,
+  \   'col': l:layout.col + 1,
+  \   'maxwidth': l:maxwidth - 2,
+  \   'maxheight': l:maxheight - 2,
   \   'filetype': 'markdown',
   \   'contents': l:document,
+  \   'winhl': 'NormalFloat:Normal',
   \ })
+
+  let l:borders = []
+  call add(l:borders, '╭' . repeat('─', min([l:layout.width, l:maxwidth])) . '╮')
+  for l:i in range(0, min([l:layout.height, l:maxheight - 2]) - 1)
+    call add(l:borders, '│' . repeat(' ', min([l:layout.width, l:maxwidth])) . '│')
+  endfor
+  call add(l:borders, '╰' . repeat('─', min([l:layout.width, l:maxwidth])) . '╯')
+  call s:border.open({
+  \   'row': l:layout.row,
+  \   'col': l:layout.col,
+  \   'maxwidth': l:maxwidth,
+  \   'maxheight': l:maxheight,
+  \   'filetype': '',
+  \   'contents': l:borders,
+  \   'winhl': 'NormalFloat:Normal',
+  \ })
+  redraw!
 endfunction
 
 "
 " compe#documentation#close
 "
 function! compe#documentation#close() abort
+  call s:border.close()
   call s:window.close()
 endfunction
 
@@ -46,25 +69,31 @@ function! s:get_screenpos(event, document) abort
   let l:total_item_count = a:event.size
   let l:current_item_index = max([complete_info(['selected']).selected, 0]) " NOTE: sometimes vim returns -2.
 
+  " compute content width.
+  let l:size = s:window.get_size({ 'contents': a:document })
+  let l:size.width += 2 " for borders.
+  let l:size.height += 2 " for borders.
+
   " create x.
-  let l:doc_width = s:window.get_size({ 'contents': a:document }).width
-  let l:col_if_right = a:event.col + a:event.width + 1 + (a:event.scrollbar ? 1 : 0)
-  let l:col_if_left = a:event.col - l:doc_width - 2
+  let l:col_if_right = a:event.col + a:event.width + (a:event.scrollbar ? 1 : 0)
+  let l:col_if_left = a:event.col - l:size.width - 1
 
   " use more big space.
   if a:event.col > (&columns - l:col_if_right)
-    let l:col = l:col_if_left
+    let l:col = l:col_if_left - 1
   else
-    let l:col = l:col_if_right
+    let l:col = l:col_if_right + 1
   endif
 
-  if l:col <= 0
-    return []
-  endif
-  if &columns <= l:col + l:doc_width
-    return []
+  if l:col <= 0 || &columns <= l:col + l:size.width
+    return {}
   endif
 
-  return [a:event.row, l:col]
+  return {
+  \   'width': l:size.width - 2,
+  \   'height': l:size.height - 2,
+  \   'row': a:event.row,
+  \   'col': l:col
+  \ }
 endfunction
 

--- a/autoload/vital/_compe/VS/Vim/Window/FloatingWindow.vim
+++ b/autoload/vital/_compe/VS/Vim/Window/FloatingWindow.vim
@@ -63,6 +63,7 @@ endfunction
 " @param {number?} args.minwidth
 " @param {number?} args.maxheight
 " @param {number?} args.minheight
+" @param {string} args.winhl
 "
 function! s:FloatingWindow.open(args) abort
   let a:args.contents = type(a:args.contents) == type('')
@@ -83,6 +84,7 @@ function! s:FloatingWindow.open(args) abort
     let self.win = s:_open(self.buf, l:style)
     call setwinvar(self.win, '&conceallevel', 2)
     call setwinvar(self.win, '&wrap', 1)
+    call setwinvar(self.win, '&winhighlight', get(a:args, 'winhl', ''))
   endif
 
   call self.set_contents(a:args.filetype, a:args.contents)

--- a/lua/compe/helper.lua
+++ b/lua/compe/helper.lua
@@ -5,14 +5,14 @@ local Helper = {}
 --- datermine
 Helper.datermine = function(context, option)
   local trigger_character_offset = 0
-  if option and option and option.trigger_characters and context.before_char ~= ' ' then
+  if option and option.trigger_characters and context.before_char ~= ' ' then
     if vim.tbl_contains(option.trigger_characters, context.before_char) then
       trigger_character_offset = context.col
     end
   end
 
   local keyword_pattern_offset
-  if option.keyword_pattern then
+  if option and option.keyword_pattern then
     keyword_pattern_offset = Pattern.get_pattern_offset(context.before_line, option.keyword_pattern)
   end
 


### PR DESCRIPTION
#58 is good approach to support border for documentation.

But it is bit difficult because the implementation relates `vim-vital-vs` too.

So I implement it with referencing #58.

TODO and other concerns.

1. It should be an option?
2. border settings.
3. we should use `strdisplaywidth` for calculate positions.

https://user-images.githubusercontent.com/629908/103150434-891e8c80-47b7-11eb-8c7b-b8fffdf4d2e4.mp4

