### PR TITLE
call vim.fn.complete when event loop is processing GUI event

### DIFF
--- a/lua/compe/completion.lua
+++ b/lua/compe/completion.lua
@@ -231,7 +231,9 @@ end
 Completion._show = function(start_offset, items)
   local completeopt = vim.o.completeopt
   vim.cmd('set completeopt=menu,menuone,noselect')
-  vim.call('complete', start_offset, items)
+  vim.schedule(function()
+      vim.call('complete', start_offset, items)
+  end)
   vim.cmd('set completeopt=' .. completeopt)
   Completion._current_offset = start_offset
   Completion._current_items = items

--- a/lua/compe/completion.lua
+++ b/lua/compe/completion.lua
@@ -229,24 +229,24 @@ end
 
 --- _show
 Completion._show = function(start_offset, items)
-  local completeopt = vim.o.completeopt
-  vim.cmd('set completeopt=menu,menuone,noselect')
   vim.schedule(function()
-      vim.call('complete', start_offset, items)
-  end)
-  vim.cmd('set completeopt=' .. completeopt)
-  Completion._current_offset = start_offset
-  Completion._current_items = items
+    local completeopt = vim.o.completeopt
+    vim.cmd('set completeopt=menu,menuone,noselect')
+    vim.call('complete', start_offset, items)
+    vim.cmd('set completeopt=' .. completeopt)
+    Completion._current_offset = start_offset
+    Completion._current_items = items
 
-  -- preselect
-  if items[1] then
-    local should_preselect = false
-    should_preselect = should_preselect or (Config.get().preselect == 'enable' and items[1].preselect)
-    should_preselect = should_preselect or (Config.get().preselect == 'always')
-    if should_preselect then
-      vim.api.nvim_select_popupmenu_item(0, false, false, {})
+    -- preselect
+    if items[1] then
+      local should_preselect = false
+      should_preselect = should_preselect or (Config.get().preselect == 'enable' and items[1].preselect)
+      should_preselect = should_preselect or (Config.get().preselect == 'always')
+      if should_preselect then
+        vim.api.nvim_select_popupmenu_item(0, false, false, {})
+      end
     end
-  end
+  end)
 end
 
 --- _should_ignore


### PR DESCRIPTION
Hello @hrsh7th, Opening a PR so we can discuss in terms of code. #61 shows
weird backspace behavior.

I feel `vim.fn.complete` should be called when the GUI event is taking place in
nvim-event-loop. This PR currently adds `vim.schedule` wrapper around it. At least
this solves it in my machine. What is the effect on your environment?

If not solves in your environment I can change work over code more as I am
interested in this cool project. :smile: