### PR TITLE
call vimscript complete only when there are items in completion list

### DIFF
--- a/lua/compe/completion.lua
+++ b/lua/compe/completion.lua
@@ -228,7 +228,7 @@ Completion._show = function(start_offset, items)
   vim.schedule(function()
     local completeopt = vim.o.completeopt
     vim.cmd('set completeopt=menu,menuone,noselect')
-    if not vim.tbl_isempty(items) then
+    if not (vim.call('pumvisible') == 0 and #items == 0) then
       vim.call('complete', start_offset, items)
     end
     vim.cmd('set completeopt=' .. completeopt)

--- a/lua/compe/completion.lua
+++ b/lua/compe/completion.lua
@@ -228,7 +228,9 @@ Completion._show = function(start_offset, items)
   vim.schedule(function()
     local completeopt = vim.o.completeopt
     vim.cmd('set completeopt=menu,menuone,noselect')
-    vim.call('complete', start_offset, items)
+    if not vim.tbl_isempty(items) then
+      vim.call('complete', start_offset, items)
+    end
     vim.cmd('set completeopt=' .. completeopt)
     Completion._current_offset = start_offset
     Completion._current_items = items


### PR DESCRIPTION
Hi @hrsh7th, in ``Completion._show`` function, vimscript ``complete`` function
is called every time even if there are no elements in ``items``.

When items are empty, we get a ``Pattern not found`` error message. This is classic
with vim's completion mechanism. However, this can be so distracting for users
many times.

This pull request adds a condition around the complete function to be called only
when there are some elements in the ``items`` table.

This removes the ``Pattern not found`` error message significantly while typing.