### PR TITLE
Add documentation for tags completion that contains all file paths.

### DIFF
--- a/autoload/compe_tags/source.vim
+++ b/autoload/compe_tags/source.vim
@@ -31,15 +31,15 @@ endfunction
 " s:documentation
 "
 function! s:documentation(args) abort
-  let word = get(a:args.completed_item, 'word', '')
-  if empty(word)
-    return
+  let l:word = get(a:args.completed_item, 'word', '')
+  if empty(l:word)
+    return a:args.abort()
   endif
-  let tags = map(taglist(word), 'v:val.filename')
-  if len(tags) > 10
-    let tags = tags[0:9] + [printf('...and %d more', len(tags[10:]))]
+  let l:tags = map(taglist(l:word), 'v:val.filename')
+  if len(l:tags) > 10
+    let l:tags = l:tags[0:9] + [printf('...and %d more', len(l:tags[10:]))]
   endif
-  return a:args.callback(tags)
+  return a:args.callback(l:tags)
 endfunction
 
 "

--- a/autoload/compe_tags/source.vim
+++ b/autoload/compe_tags/source.vim
@@ -5,6 +5,7 @@ function! compe_tags#source#create() abort
   return {
   \   'get_metadata': function('s:get_metadata'),
   \   'datermine': function('s:datermine'),
+  \   'documentation': function('s:documentation'),
   \   'complete': function('s:complete')
   \ }
 endfunction
@@ -24,6 +25,21 @@ endfunction
 "
 function! s:datermine(context) abort
   return compe#helper#datermine(a:context)
+endfunction
+
+"
+" s:documentation
+"
+function! s:documentation(args) abort
+  let word = get(a:args.completed_item, 'word', '')
+  if empty(word)
+    return
+  endif
+  let tags = map(taglist(word), 'v:val.filename')
+  if len(tags) > 10
+    let tags = tags[0:9] + [printf('...and %d more', len(tags[10:]))]
+  endif
+  return a:args.callback(tags)
 endfunction
 
 "


### PR DESCRIPTION
This PR adds documentation floating window for tags completion that contains all file paths where tag is defined.
This is useful when you rely a lot on tags completion (which I do in javascript projects), and i'm not always 100% sure if certain thing exist in certain file. This helps a lot.

Here are few screenshots:

Less than 10 entries:

![less_then_10_entries](https://i.imgur.com/W1AwFZn.png)


10 entries is maximum. Everything else is truncated:

![over_10_entries](https://i.imgur.com/oUBpXQL.png)