### PR TITLE
Remove duplicate paths from tags completion documentation.

### DIFF
--- a/autoload/compe_tags/source.vim
+++ b/autoload/compe_tags/source.vim
@@ -35,7 +35,7 @@ function! s:documentation(args) abort
   if empty(l:word)
     return a:args.abort()
   endif
-  let l:tags = map(taglist(l:word), 'v:val.filename')
+  let l:tags = uniq(map(taglist(l:word), 'v:val.filename'))
   if len(l:tags) > 10
     let l:tags = l:tags[0:9] + [printf('...and %d more', len(l:tags[10:]))]
   endif


### PR DESCRIPTION
I noticed that there are a lot of duplicate paths for tags documentation that I added today, even on the screenshot I attached:

![screenshot](https://camo.githubusercontent.com/85cc849904af7bdddbecefd26057c7d440a03597c60854e8763665e684091198/68747470733a2f2f692e696d6775722e636f6d2f6f55427058514c2e706e67)

This is how it looks now:

![after_screenshot](https://i.imgur.com/26Cc5Hi.png)

There are still some duplicates since the list is not sorted, but I don't want to sort it since things should be sorted as they appear in tags file, at least that seems more natural to me. So much duplicates are generally very rare and only for keywords that occur so much.