### PR TITLE
refresh completion when no new items are available

### DIFF
--- a/lua/compe/completion.lua
+++ b/lua/compe/completion.lua
@@ -140,9 +140,7 @@ Completion._trigger = function(context)
     local status, value = pcall(function()
       trigger = source:trigger(context, (function(source)
         return function()
-          if #source.items > 0 then
-            Completion._display(Context.new({}))
-          end
+          Completion._display(Context.new({}))
         end
       end)(source)) or trigger
     end)


### PR DESCRIPTION
Hello @hrsh7th, This PR indents to refresh current completion even if no new
items are there for source. (i.e., when #source.items == 0)

This may not be the best way to achieve it, but it certainly would improve
behavior.

I would show it in gif.

Before:
![before](https://user-images.githubusercontent.com/26287448/104422543-e92c7580-55a2-11eb-9368-a3b0ef761177.gif)



After:
![after](https://user-images.githubusercontent.com/26287448/104422556-ee89c000-55a2-11eb-9977-1af7db8be0cf.gif)

If you feel there is a better way to achieve it please tell me, I would change that in PR.:smiley: