### PR TITLE
Remove &rtp search for ultisnips

### DIFF
--- a/after/plugin/compe_ultisnips.vim
+++ b/after/plugin/compe_ultisnips.vim
@@ -1,4 +1,4 @@
-if match(&runtimepath, 'UltiSnips') == -1 || exists('g:loaded_compe_ultisnips')
+if exists('g:loaded_compe_ultisnips')
   finish
 endif
 let g:loaded_compe_ultisnips = v:true

--- a/lua/compe_ultisnips/init.lua
+++ b/lua/compe_ultisnips/init.lua
@@ -15,7 +15,7 @@ function M:datermine(context)
 end
 
 function M:complete(args)
-  local received_snippets = vim.call('UltiSnips#SnippetsInCurrentScope')
+  local received_snippets = vim.F.npcall(vim.call, 'UltiSnips#SnippetsInCurrentScope') or {}
   if vim.tbl_isempty(received_snippets) then
     args.abort()
     return


### PR DESCRIPTION
Use `vim.F.npcall` to catch error instead, allowing ultisnips to be added to `&rtp` after nvim startup. Useful for those who do on-demand loading using built-in packages.

Also, the `match()` was reliant on the `ignorecase` setting; in my case (`noignorecase` set), it failed to match ultisnips even though it is installed and added via `packadd! ultisnips` in init.vim.

With this change, `vim.F.npcall()` will return `nil` if the call to `UltiSnips#{...}` fails -- meaning someone has added ultisnips as a completion source but doesn't have it loaded in nvim.
