### PR TITLE
Add option to disable autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ vim.o.completeopt = "menu,menuone,noselect"
 ### Available Options
 
 - `compe.enabled (bool)`: Whether or not nvim-compe is enabled. default: `true`.
+- `compe.autocomplete (bool)`: Whether or not nvim-compe opens the popup menu automatically. default: `true`.
 - `compe.debug (bool)`: Whether or not nvim-compe should display debug info. default: `false`
 - `compe.min_length (number)`: Minimal characters length to trigger completion. default: `1`
 - `compe.preselect ("enable" | "disable" | "always")`
@@ -75,6 +76,7 @@ Both Vimscript and Lua example are using the default value.
 ```viml
 let g:compe = {}
 let g:compe.enabled = v:true
+let g:compe.autocomplete = v:true
 let g:compe.debug = v:false
 let g:compe.min_length = 1
 let g:compe.preselect = 'enable'
@@ -96,6 +98,7 @@ let g:compe.source.your_awesome_source = {}
 ```lua
 require'compe'.setup {
   enabled = true;
+  autocomplete = true;
   debug = false;
   min_length = 1;
   preselect = 'enable';

--- a/lua/compe/completion.lua
+++ b/lua/compe/completion.lua
@@ -119,10 +119,12 @@ Completion.complete = function(manual)
     Completion._show(Completion._current_offset, Completion._current_items)
   end
 
-  local should_trigger = is_completing or not Completion._context:maybe_backspace(context)
-  if should_trigger then
-    if not Completion._trigger(context) then
-      Completion._display(context)
+  if Config.get().autocomplete or (manual or is_completing) then
+    local should_trigger = is_completing or not Completion._context:maybe_backspace(context)
+    if should_trigger then
+      if not Completion._trigger(context) then
+        Completion._display(context)
+      end
     end
   end
 

--- a/lua/compe/config.lua
+++ b/lua/compe/config.lua
@@ -18,6 +18,11 @@ Config.setup = function(config)
   config.source_timeout = config.source_timeout or SOURCE_TIMEOUT
   config.incomplete_delay = config.incomplete_delay or INCOMPLETE_DELAY
   config.allow_prefix_unmatch = Config._true(config.allow_prefix_unmatch)
+  if config.autocomplete == nil then
+    config.autocomplete = true
+  else
+    config.autocomplete = Config._true(config.autocomplete)
+  end
 
   -- normalize source metadata
   for name, metadata in pairs(config.source) do


### PR DESCRIPTION
if `let g:compe.autocomplete` is set to false, completion only triggers manually

fix #88

Let me know if you want to change the name to something better.
`completion-nvim` calls it `completion_enable_auto_popup`.