### PR TITLE
Add Ultisnips Confirm Function

### DIFF
--- a/lua/compe_ultisnips/init.lua
+++ b/lua/compe_ultisnips/init.lua
@@ -46,4 +46,8 @@ function M:documentation(args)
   args.callback(user_data)
 end
 
+function M:confirm(_, _)
+  vim.call('UltiSnips#ExpandSnippet')
+end
+
 return M


### PR DESCRIPTION
Add a confirm function for the ultisnips completion source. Ultisnips normally has its own expand trigger, but mapping it to `<CR>` can be problematic as it interferes with a lot of other plugins that try to map the same key. When used in conjunction with such plugins, I think it is better to defer to nvim-compe's completion.