### PR TITLE
refactor: move vim.fn to vim.api whenever possible

### DIFF
--- a/lua/compe/context.lua
+++ b/lua/compe/context.lua
@@ -3,13 +3,13 @@ local Context = {}
 function Context.new(option)
   local self = setmetatable({}, { __index = Context })
   self.time = vim.loop.now()
-  self.changedtick = vim.fn.getbufvar('%', 'changedtick', 0)
+  self.changedtick = vim.b.changedtick or 0
   self.manual = option.manual or false
-  self.lnum = vim.fn.line('.')
-  self.col = vim.fn.col('.')
-  self.bufnr = vim.fn.bufnr('%')
-  self.filetype = vim.fn.getbufvar('%', '&filetype', '')
-  self.line = vim.fn.getline('.')
+  self.lnum = vim.api.nvim_win_get_cursor(0)[1]
+  self.col = vim.api.nvim_win_get_cursor(0)[2] + 1 -- zero-based index
+  self.bufnr = vim.api.nvim_get_current_buf()
+  self.filetype = vim.bo.filetype or ''
+  self.line = vim.api.nvim_get_current_line()
   self.before_line = string.sub(self.line, 1, self.col - 1)
   self.before_char = self:get_before_char(self.lnum, self.before_line)
   self.after_line = string.sub(self.line, self.col, -1)
@@ -38,7 +38,7 @@ end
 function Context.get_before_char(_, lnum, before_line)
   local current_lnum = lnum
   while current_lnum > 0 do
-    local line = current_lnum == lnum and before_line or vim.fn.getline(current_lnum)
+    local line = current_lnum == lnum and before_line or vim.api.nvim_get_current_line()
     local _, _, c = string.find(line, '([^%s])%s*$')
     if c ~= nil then
       break

--- a/lua/compe_buffer/init.lua
+++ b/lua/compe_buffer/init.lua
@@ -73,7 +73,7 @@ function Source._get_buffers(self)
     if not self.buffers[buf] then
       local buffer = Buffer.new(
         buf,
-        compe.helper.get_keyword_pattern(vim.fn.getbufvar(buf, '&filetype')),
+        compe.helper.get_keyword_pattern(vim.bo.filetype),
         compe.helper.get_default_pattern()
       )
       buffer:index()

--- a/lua/compe_nvim_lsp/init.lua
+++ b/lua/compe_nvim_lsp/init.lua
@@ -5,9 +5,11 @@ local source_ids = {}
 
 return {
   attach = function()
-    vim.fn.execute('augroup compe_nvim_lsp')
-    vim.fn.execute('autocmd InsertEnter * lua require"compe_nvim_lsp".register()')
-    vim.fn.execute('augroup END')
+    vim.api.nvim_exec([[
+      augroup compe_nvim_lsp
+      autocmd InsertEnter * lua require"compe_nvim_lsp".register()
+      augroup END
+    ]], false)
   end;
   register = function()
     -- unregister
@@ -16,7 +18,7 @@ return {
     end
 
     -- register
-    local filetype = vim.fn.getbufvar('%', '&filetype')
+    local filetype = vim.bo.filetype
     for id, client in pairs(vim.lsp.buf_get_clients(0)) do
       table.insert(source_ids, compe.register_source('nvim_lsp', Source.new(client, filetype)))
     end

--- a/lua/compe_path/init.lua
+++ b/lua/compe_path/init.lua
@@ -143,8 +143,8 @@ end
 
 --- _is_slash_comment
 Source._is_slash_comment = function(_)
-  local commentstring = vim.fn.getbufvar('%', '&commentstring') or ''
-  local no_filetype = vim.fn.getbufvar('%', '&filetype') == ''
+  local commentstring = vim.bo.commentstring or ''
+  local no_filetype = vim.bo.filetype == ''
   local is_slash_comment = false
   is_slash_comment = is_slash_comment or commentstring:match('/%*')
   is_slash_comment = is_slash_comment or commentstring:match('//')

--- a/lua/compe_vsnip/init.lua
+++ b/lua/compe_vsnip/init.lua
@@ -17,7 +17,7 @@ function Source.determine(_, context)
 end
 
 function Source.complete(_, context)
-  local items = vim.fn['vsnip#get_complete_items'](vim.fn.bufnr('%'))
+  local items = vim.fn['vsnip#get_complete_items'](vim.api.nvim_get_current_buf())
 
   local add_user_data = function(item)
     item.user_data = { compe = item.user_data }
@@ -36,7 +36,7 @@ function Source.documentation(_, args)
   table.insert(document, '```' .. args.context.filetype)
 
   local decoded= vim.fn['vsnip#to_string'](vim.fn.json_decode(args.completed_item.user_data.compe).vsnip.snippet)
-  for _, line in ipairs(vim.fn.split(decoded, "\n")) do
+  for _, line in ipairs(vim.split(decoded, "\n")) do
     table.insert(document, line)
   end
   table.insert(document, '```')


### PR DESCRIPTION
use `vim.api` to replace `vim.fn` when possible, the performance should increase slightly, I think.
I did this because I saw this chat on Neovim's Gitter.

I haven't tested it thoroughly cause I don't have enough time atm, but from what I experienced, nothing's broken.

![image](https://user-images.githubusercontent.com/51877647/106823704-00e3af00-66b4-11eb-9ff3-b721518347ee.png)
