### PR TITLE
fix: avoid creating swapfiles for preview buffers

### DIFF
--- a/autoload/compe/documentation.vim
+++ b/autoload/compe/documentation.vim
@@ -11,6 +11,7 @@ call s:window.set_bufnr(s:Buffer.create())
 call setbufvar(s:window.get_bufnr(), '&buftype', 'nofile')
 call setbufvar(s:window.get_bufnr(), '&bufhidden', 'hide')
 call setbufvar(s:window.get_bufnr(), '&buflisted', 0)
+call setbufvar(s:window.get_bufnr(), '&swapfile', 0)
 
 "
 " compe#documentation#show


### PR DESCRIPTION
Sometimes Neovim fails to delete swapfiles which can result in repeated error messages upon re-opening the editor

Thanks for maintaining this really nice plugin!