### PR TITLE
Add snippet expansion to docs and FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Auto completion plugin for nvim.
   - [Neovim-specific](#neovim-specific)
   - [External-plugin](#external-plugin)
 - [FAQ](#faq)
-  - [How to use LSP snippet?](#how-to-use-lsp-snippet-)
-  - [How to use tab to navigate completion menu?](#how-to-use-tab-to-navigate-completion-menu-)
+  - [How to use LSP snippet?](#how-to-use-lsp-snippet)
+  - [How to use tab to navigate completion menu?](#how-to-use-tab-to-navigate-completion-menu)
+  - [How to expand snippets from completion menu?](#how-to-expand-snippets-from-completion-menu)
 - [Demo](#demo)
   - [Auto Import](#auto-import)
   - [LSP + Magic Completion](#lsp--rust_analyzers-magic-completion)
@@ -251,6 +252,10 @@ vim.api.nvim_set_keymap("s", "<Tab>", "v:lua.tab_complete()", {expr = true})
 vim.api.nvim_set_keymap("i", "<S-Tab>", "v:lua.s_tab_complete()", {expr = true})
 vim.api.nvim_set_keymap("s", "<S-Tab>", "v:lua.s_tab_complete()", {expr = true})
 ```
+
+### How to expand snippets from completion menu?
+
+Use `compe#confirm()` mapping, as described in section [Mappings](#mappings).
 
 ## Demo
 

--- a/doc/compe.txt
+++ b/doc/compe.txt
@@ -101,6 +101,9 @@ For Raimondi/delimitMate:
   inoremap <silent><expr> <CR>      compe#confirm({'keys': "\<Plug>delimitMateCR", 'mode': ''})
   inoremap <silent><expr> <C-e>     compe#close('<C-e>')
 <
+Some sources might rely on |compe#confirm()| mapping. For example, to expand
+snippets from the completion menu, you have to use |compe#confirm()| mapping.
+
 
 ==============================================================================
 FUNCTIONS                                                    *compe-functions*
@@ -153,7 +156,7 @@ compe#close([{fallback}])                                      *compe#close()*
 <
 compe#helper#*()                                                *compe#helper*
     Source helpers.
->
+
 
 ------------------------------------------------------------------------------
 LUA                                                                *compe-lua*
@@ -393,7 +396,7 @@ Lua:
       snippets_nvim = true;
     };
   }
->
+<
 
 ==============================================================================
 CUSTOM SOURCE                                            *compe-custom-source*


### PR DESCRIPTION
- fixed invalid formatting in vim docs
- fixed links to FAQ in table of contents in README.md

I saw some people asking how to expand snippets from the completion menu. There was no mention how to do that.