### PR TITLE
Add omni completion source

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ let g:compe.source.spell = v:true
 let g:compe.source.tags = v:true
 let g:compe.source.snippets_nvim = v:true
 let g:compe.source.treesitter = v:true
+let g:compe.source.omni = v:true
 ```
 
 #### Lua Config
@@ -184,6 +185,7 @@ inoremap <silent><expr> <C-d>     compe#scroll({ 'delta': -4 })
 - tags
 - spell
 - calc
+- omni
 
 ### Neovim-specific
 

--- a/after/plugin/compe_omni.vim
+++ b/after/plugin/compe_omni.vim
@@ -1,0 +1,9 @@
+if exists('g:loaded_compe_omni')
+  finish
+endif
+let g:loaded_compe_omni = v:true
+
+if exists('g:loaded_compe')
+  lua require'compe'.register_source('omni', require'compe_omni')
+endif
+

--- a/doc/compe.txt
+++ b/doc/compe.txt
@@ -336,6 +336,7 @@ buffer              Buffer completion.
 tags                Tag completion.
 spell               Spell file completion.
 calc                Lua math expressions.
+omni                Omni completion.
 
 Neovim-specific: ~
 nvim_lsp            Neovim's builtin LSP completion.
@@ -384,6 +385,7 @@ Vimscript:
   let g:compe.source.spell = v:true
   let g:compe.source.tags = v:true
   let g:compe.source.snippets_nvim = v:true
+  let g:compe.source.omni = v:true
 <
 Lua:
 >
@@ -411,6 +413,7 @@ Lua:
       spell = true;
       tags = true;
       snippets_nvim = true;
+      omni = true;
     };
   }
 <

--- a/lua/compe_omni/init.lua
+++ b/lua/compe_omni/init.lua
@@ -1,0 +1,37 @@
+local compe = require("compe")
+local Source = {}
+
+function Source.new()
+  return setmetatable({}, { __index = Source })
+end
+
+function Source.get_metadata(_)
+  return {
+    priority = 100;
+    dup = 0;
+    menu = '[Omni]';
+  }
+end
+
+function Source.determine(_, context)
+  local fn = vim.bo.omnifunc
+  if fn == '' then
+    return nil
+  end
+  local completion_start_column = vim.api.nvim_call_function(fn, { 1, '' })
+  if completion_start_column == -2 or completion_start_column == -3 then
+    return nil
+  elseif completion_start_column < 0 then
+    completion_start_column = vim.api.nvim_win_get_cursor(0)[2]
+  end
+  return {
+    keyword_pattern_offset = completion_start_column + 1,
+  }
+end
+
+function Source.complete(_, context)
+  context.callback({ items = vim.api.nvim_call_function(vim.bo.omnifunc, { 0, context.input }) })
+end
+
+return Source.new()
+


### PR DESCRIPTION
This is a basic source that works, but I think that it should be filetype-specific, because it is only relevant in a few cases (e.g. when editing LaTeX files when https://github.com/lervag/vimtex is installed). However, there isn't a good way for users to configure filetypes for sources right now, since they don't have access to the source metadata.

It would be easy to add a global option and read it in `get_metadata` but that's quite ugly in my opinion.

Ideally, I'd like to configure filetypes via files in an `ftplugin` directory (which only works for Vimscript, [Lua support is planned for 0.6](https://github.com/neovim/neovim/issues/12670), which is still far away) or autocommands. I feel that it shouldn't be the responsibility of a plugin to handle filetype management since (Neo)Vim already has a very good way to do that.
I can open an issue to discuss that if you don't have a plan for it yet.