### PR TITLE
Don't show resolve is detail is ''.

### DIFF
--- a/lua/compe_nvim_lsp/source.lua
+++ b/lua/compe_nvim_lsp/source.lua
@@ -98,7 +98,7 @@ end
 --- _create_document
 function Source._create_document(self, filetype, completion_item)
   local document = {}
-  if completion_item.detail then
+  if completion_item.detail and completion_item.detail ~= '' then
     table.insert(document, '```' .. filetype)
     table.insert(document, completion_item.detail)
     table.insert(document, '```')


### PR DESCRIPTION
Some servers will respond with the detail field, but with an empty
string. If this happens an empty window is shown. This just adds another
simple check to ensure that the window isn't shown if the detail is ''.

Before:

<img width="1384" alt="Screenshot 2021-02-13 at 12 55 51" src="https://user-images.githubusercontent.com/13974112/107849312-d784fa80-6dfa-11eb-8083-ccd65bd82336.png">

After:

<img width="1384" alt="Screenshot 2021-02-13 at 12 55 22" src="https://user-images.githubusercontent.com/13974112/107849316-dce24500-6dfa-11eb-9fae-33d0f980e7f2.png">
