### PR TITLE
RFC: Temporary detail field solution before  LSP 3.17

### DIFF
--- a/lua/compe/completion.lua
+++ b/lua/compe/completion.lua
@@ -195,7 +195,11 @@ Completion._display = guard(function(context)
           item.word = item.original_word
           item.abbr = item.original_abbr
           item.kind = item.original_kind or ''
-          item.menu = item.original_menu or ''
+          if context.manual and item.detail then
+            item.menu = item.detail
+          else
+            item.menu = item.original_menu or ''
+          end
 
           -- trim to specified width.
           item.abbr = String.trim(item.abbr, Config.get().max_abbr_width)

--- a/lua/compe/helper.lua
+++ b/lua/compe/helper.lua
@@ -117,6 +117,7 @@ Helper.convert_lsp = function(args)
       word = word;
       abbr = abbr;
       kind = vim.lsp.protocol.CompletionItemKind[completion_item.kind] or nil;
+      detail = completion_item.detail;
       user_data = {
         compe = {
           request_position = request.position;


### PR DESCRIPTION
Use the detail field instead of the menu field if manual completion is triggered.

Related #209