### PR TITLE
Add kind mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ let g:compe.max_abbr_width = 100
 let g:compe.max_kind_width = 100
 let g:compe.max_menu_width = 100
 let g:compe.documentation = v:true
+let g:compe.kind_mapping =  {"Function" = ""; "Interface" = "擄";};
+
 
 let g:compe.source = {}
 let g:compe.source.path = v:true
@@ -127,6 +129,7 @@ require'compe'.setup {
   max_kind_width = 100;
   max_menu_width = 100;
   documentation = true;
+  kind_mapping = {["Function"] = ""; ["Interface"] = "擄";};
 
   source = {
     path = true;
@@ -207,7 +210,6 @@ inoremap <silent><expr> <C-d>     compe#scroll({ 'delta': -4 })
 - [zsh](https://github.com/tamago324/compe-zsh)
 - [conjure](https://github.com/tami5/compe-conjure)
 - [dadbod](https://github.com/kristijanhusak/vim-dadbod-completion)
-
 
 ## FAQ
 

--- a/doc/compe.txt
+++ b/doc/compe.txt
@@ -285,6 +285,12 @@ documentation ~
       Type: |Boolean|
       Default: true
 
+kind_mapping ~
+    Lsp kind string mapping.  .e.g LSP kind "Function" can be mapped to
+    "" by define {"Function" = ""}
+      Type: Dictionary
+      Default: empty
+
 source ~
     Source configuration. Required.
       Type: |Dictionary| of:

--- a/lua/compe/completion.lua
+++ b/lua/compe/completion.lua
@@ -197,6 +197,7 @@ Completion._display = guard(function(context)
           item.kind = item.original_kind or ''
           item.menu = item.original_menu or ''
 
+          item.kind = Config.get().kind_mapping[item.kind] or item.kind
           -- trim to specified width.
           item.abbr = String.trim(item.abbr, Config.get().max_abbr_width)
           item.kind = String.trim(item.kind, Config.get().max_kind_width)
@@ -307,4 +308,3 @@ Completion._get_start_offset = function(context)
 end
 
 return Completion
-

--- a/lua/compe/config.lua
+++ b/lua/compe/config.lua
@@ -55,6 +55,7 @@ Config._normalize = function(config)
   config.source_timeout = config.source_timeout or SOURCE_TIMEOUT
   config.incomplete_delay = config.incomplete_delay or INCOMPLETE_DELAY
   config.allow_prefix_unmatch = Boolean.get(config.allow_prefix_unmatch, false)
+  config.kind_mapping = config.kind_mapping or {}
   config.max_abbr_width = config.max_abbr_width or 100
   config.max_kind_width = config.max_kind_width or 100
   config.max_menu_width = config.max_menu_width or 100
@@ -78,4 +79,3 @@ Config._normalize = function(config)
 end
 
 return Config
-


### PR DESCRIPTION
This is a port from complete-nvim feature which will show LSP kinds to a nerdfont
e.g {["Function"] = ""; ["Interface"] = "擄";}

<img width="786" alt="Screen Shot 2021-02-26 at 4 14 59 pm" src="https://user-images.githubusercontent.com/1681295/109258178-db2e6d80-784d-11eb-9cef-8b1cc6435e01.png">
