### PR TITLE
Improve perf

### DIFF
--- a/lua/compe/completion.lua
+++ b/lua/compe/completion.lua
@@ -113,7 +113,9 @@ Completion.select = function(args)
     if args.documentation and Config.get().documentation then
       for _, source in ipairs(Completion.get_sources()) do
         if source.id == completed_item.source_id then
-          source:documentation(completed_item)
+          vim.schedule(Async.guard('documentation', function()
+            source:documentation(completed_item)
+          end))
           break
         end
       end

--- a/lua/compe/completion.lua
+++ b/lua/compe/completion.lua
@@ -120,6 +120,10 @@ Completion.select = function(args)
         end
       end
     end
+  else
+    vim.schedule(Async.guard('documentation', function()
+      vim.call('compe#documentation#close')
+    end))
   end
 end
 
@@ -256,12 +260,6 @@ Completion._show = function(start_offset, items, context)
   Completion._current_offset = start_offset
   Completion._current_items = items
   Async.throttle('Completion._show', timeout, Async.guard('Completion._show', guard(function()
-    if prev_should_visible then
-      if not next_should_visible or pummove then
-        vim.call('compe#documentation#close')
-      end
-    end
-
     local should_preselect = false
     if items[1] then
       should_preselect = should_preselect or (Config.get().preselect == 'enable' and items[1].preselect)
@@ -277,11 +275,8 @@ Completion._show = function(start_offset, items, context)
     vim.call('complete', math.max(1, start_offset), items) -- start_offset=0 should close pum with `complete(1, [])`
     vim.cmd('set completeopt=' .. completeopt)
 
-    if context.prev_context.pumvisible and context.pumvisible and should_preselect then
-      Completion.select({
-        index = 0,
-        documentation = true
-      })
+    if context.prev_context.pumvisible and not context.pumvisible then
+      vim.call('compe#documentation#close')
     end
   end)))
 end

--- a/lua/compe/source.lua
+++ b/lua/compe/source.lua
@@ -173,11 +173,11 @@ Source.trigger = function(self, context, callback)
         self:clear()
       end
 
-      Async.fast_schedule(callback)
+      vim.schedule(callback)
     end;
     abort = function()
       self:clear()
-      Async.fast_schedule(callback)
+      vim.schedule(callback)
     end;
   })
   return true
@@ -221,21 +221,21 @@ Source.documentation = function(self, completed_item)
         self.source:documentation({
           completed_item = resolved_completed_item;
           context = Context.new({}, {});
-          callback = Async.guard('Source.documentation#callback', Async.fast_schedule_wrap(function(document)
+          callback = Async.guard('Source.documentation#callback', vim.schedule_wrap(function(document)
             if document and #document ~= 0 then
               vim.call('compe#documentation#open', document)
             else
               vim.call('compe#documentation#close')
             end
           end));
-          abort = Async.guard('Source.documentation#abort', Async.fast_schedule_wrap(function()
+          abort = Async.guard('Source.documentation#abort', vim.schedule_wrap(function()
             vim.call('compe#documentation#close')
           end));
         })
       end
     })
   else
-    Async.fast_schedule(function()
+    vim.schedule_wrap(function()
       vim.call('compe#documentation#close')
     end)
   end

--- a/lua/compe/utils/async.lua
+++ b/lua/compe/utils/async.lua
@@ -18,37 +18,22 @@ Async.once = function(callback)
   end
 end
 
--- fast_schedule_wrap
-Async.fast_schedule_wrap = function(callback)
-  return function(...)
-    local args = ...
-    Async.fast_schedule(function()
-      callback(args)
-    end)
-  end
-end
-
--- fast_schedule
-Async.fast_schedule = function(callback)
-  if vim.in_fast_event() then
-    vim.schedule(callback)
-  else
-    callback()
-  end
-end
-
 -- set_timeout
 Async.set_timeout = function(callback, timeout)
   Async._base_timer_id = Async._base_timer_id + 1
 
   if timeout <= 0 then
-    Async.fast_schedule(callback)
+    if vim.in_fast_event() then
+      vim.schedule(callback)
+    else
+      callback()
+    end
     return -1
   end
 
   local timer_id = Async._base_timer_id
   Async._timers[timer_id] = vim.loop.new_timer()
-  Async._timers[timer_id]:start(timeout, 0, Async.fast_schedule_wrap(function()
+  Async._timers[timer_id]:start(timeout, 0, vim.schedule_wrap(function()
     Async.clear_timeout(timer_id)
     callback()
   end))


### PR DESCRIPTION
1. Avoid too many compe#documentation calls
  - done

2. Avoid too many table.sort calls
  - I had wrong thoughts. We can't it.

I have a very large TypeScript codebase. nvim-compe will have a lag if completion in it.

Finally, I found a solution that just removes the `in_fast_event` check in the async.lua.
