### PR TITLE
Add suppress_on_manual source configuration option

### DIFF
--- a/doc/compe.txt
+++ b/doc/compe.txt
@@ -344,6 +344,11 @@ menu ~
     Specify item's menu (see |complete-items|)
       Type: |String|
 
+suppress_on_manual ~
+    Specify whether the source should provide candidates when completion is
+    triggered manually by |compe#complete()|.
+      Type: |Boolean|
+
 
 ------------------------------------------------------------------------------
 BUILTIN SOURCES                                                *compe-sources*

--- a/lua/compe/source.lua
+++ b/lua/compe/source.lua
@@ -85,6 +85,10 @@ Source.trigger = function(self, context, callback)
   local characters = state.trigger_character_offset > 0
   local incomplete = self.incomplete and not empty
 
+  if manual and metadata.suppress_on_manual then
+    return self:clear()
+  end
+
   -- Clear current completion if all filter words removed.
   if self.status == 'completed' and not (manual or characters) then
     if context.col == self.keyword_pattern_offset then


### PR DESCRIPTION
This PR adds a new source configuration option, `suppress_on_manual` (boolean), to control whether a source should provide candidates when completion is manually triggered by `compe#complete()`. 

I'm using the `priority` option to make sure that my snippets from vim-vsnip always show up first, but they can get in the way when I trigger manual completion. For example, if I trigger completion to see all the properties of a TypeScript JSX element, I have to scroll through my snippets before I can see the properties I'm interested in: 

<img width="397" alt="Screen Shot 2021-03-17 at 7 27 42 PM" src="https://user-images.githubusercontent.com/54108223/111453427-e989ee00-8756-11eb-998a-4568e6136db0.png">

With `suppress_on_manual` set to `true` for compe's vsnip source, snippets won't appear, so I only see what I care about: 

<img width="294" alt="Screen Shot 2021-03-17 at 7 29 45 PM" src="https://user-images.githubusercontent.com/54108223/111453844-5b623780-8757-11eb-8edf-4e52db082309.png">

The code is quite trivial, so let me know if this seems useful, and thanks again for the great plugin. 