### PR TITLE
Enclose item documentation as Markdown code-block

### DIFF
--- a/lua/compe_nvim_lsp/source.lua
+++ b/lua/compe_nvim_lsp/source.lua
@@ -104,12 +104,14 @@ function Source._create_document(self, filetype, completion_item)
     table.insert(document, '```')
   end
   if completion_item.documentation then
+    table.insert(document, '```' .. filetype)
     if completion_item.detail then
       table.insert(document, ' ')
     end
     for _, line in ipairs(util.convert_input_to_markdown_lines(completion_item.documentation)) do
       table.insert(document, line)
     end
+    table.insert(document, '```')
   end
   return document
 end


### PR DESCRIPTION
I think this change may solve #260 

![Screenshot from 2021-03-18 16-27-55](https://user-images.githubusercontent.com/102958/111685971-4a70ff00-8807-11eb-848b-bb52650dd635.png)

Star (`*`) characters don't get interpreted as Markdown bold syntax and Python's built-in types get syntax color as if interpreted as code.