### PR TITLE
Fix problem with doautocmd and modeline

### DIFF
--- a/lua/compe/completion.lua
+++ b/lua/compe/completion.lua
@@ -100,7 +100,7 @@ Completion.confirm = function()
   end
   Completion.close()
 
-  vim.cmd([[doautocmd User CompeConfirmDone]])
+  vim.cmd([[doautocmd <nomodeline> User CompeConfirmDone]])
 
   Completion.complete({ trigger_character_only = true })
 end


### PR DESCRIPTION
This fixes an issue i had trying to use nvim-compe while editing files with foldmarkers and a modeline. Everytime i pressed enter to confirm a completion item all my folds were getting closed. I found out that `doautocmd` reloads the `modeline` which caused `foldlevel=0` from my modeline to be run again. Fortunately this can be suppressed using the `<nomodeline>` flag. I replaced every `doautocmd` call with `doautocmd <nomodeline>`.

## Example
Use the following file and command to reproduce: `nvim --clean -u test.vim test.vim`
```vim
" Test {{{
set modeline
au User Test echom 'test'
" }}}

" vim: foldmethod=marker foldenable foldlevel=0
```
![102778352-b7086900-4392-11eb-948e-f316b483b50d](https://user-images.githubusercontent.com/9465658/111885411-e8132c80-89c7-11eb-8d5e-b41d0254eb1f.gif)
