### PR TITLE
Add compe-latex-symbols to external sources list

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ highlight link CompeDocumentation NormalFloat
 - [zsh](https://github.com/tamago324/compe-zsh)
 - [conjure](https://github.com/tami5/compe-conjure)
 - [dadbod](https://github.com/kristijanhusak/vim-dadbod-completion)
+- [latex-symbols](https://github.com/GoldsteinE/compe-latex-symbols)
 
 
 ## FAQ


### PR DESCRIPTION
Hi!
I made a simple source to insert unicode symbols by autocompleting latex \codes. I'd like to add it to README external sources list.