### PR TITLE
Optionally expand LSP-Snippets with LuaSnip

### DIFF
--- a/autoload/compe/confirmation.vim
+++ b/autoload/compe/confirmation.vim
@@ -30,6 +30,8 @@ function! s:expand_snippet(args) abort
     call vsnip#anonymous(a:args.body)
   elseif luaeval('pcall(require, "snippets")')
     call luaeval('require"snippets".expand_at_cursor((require"snippets".u.match_indentation(_A)))', a:args.body)
+  elseif luaeval('pcall(require, "luasnip")')
+  	call luaeval('require"luasnip".lsp_expand(_A)', a:args.body)
   else
     call s:simple_expand_snippet(a:args.body)
   endif


### PR DESCRIPTION
Hi, I recently wrote a [snippet plugin](https://github.com/L3MON4D3/LuaSnip) for Neovim and would like to add some support for it here.