### PR TITLE
Improve LuaSnip completion

### DIFF
--- a/lua/compe_luasnip/init.lua
+++ b/lua/compe_luasnip/init.lua
@@ -1,17 +1,18 @@
 local compe = require("compe")
 local Source = {}
-local luasnip = require"luasnip"
+local luasnip = require "luasnip"
+local util = require "vim.lsp.util"
 
 function Source.new()
-  return setmetatable({}, { __index = Source })
+  return setmetatable({}, {__index = Source})
 end
 
 function Source.get_metadata(_)
   return {
-    priority = 10;
+    priority = 10,
     -- keep Snippets with same trigger but different filetype.
-    dup = true;
-    menu = '[Snippets]';
+    dup = true,
+    menu = "[Snippets]"
   }
 end
 
@@ -19,22 +20,25 @@ function Source.determine(_, context)
   return compe.helper.determine(context)
 end
 
-function Source.documentation(self, context)
-  local item = context.completed_item
-  context.callback(luasnip.snippets[item.kind][item.user_data.ft_indx].dscr)
+function Source.documentation(self, args)
+  local item = args.completed_item
+  local snip = luasnip.snippets[item.kind][item.user_data.ft_indx]
+  local header = (snip.name or "") .. " - `[" .. args.context.filetype .. "]`\n"
+  local documentation = header .. string.rep("=", string.len(header) - 3) .. "\n\n" .. (snip.dscr or "")
+  args.callback(util.convert_input_to_markdown_lines(documentation))
 end
 
 function Source.complete(_, context)
   local items = {}
 
   local filetypes = vim.split(vim.bo.filetype, ".", true)
-  filetypes[#filetypes+1] = "all"
+  filetypes[#filetypes + 1] = "all"
   for i = 1, #filetypes do
     local ft_table = luasnip.snippets[filetypes[i]]
     if ft_table then
       for j, snip in ipairs(ft_table) do
-        items[#items+1] = {
-          word = snip.name or snip.trigger,
+        items[#items + 1] = {
+          word = snip.trigger,
           kind = filetypes[i],
           abbr = snip.trigger,
           user_data = {
@@ -46,16 +50,16 @@ function Source.complete(_, context)
     end
   end
 
-  context.callback({
-    items = items
-  })
+  context.callback(
+    {
+      items = items
+    }
+  )
 end
 
 function Source.confirm(_, context)
   local item = context.completed_item
   local snip = luasnip.snippets[item.kind][item.user_data.ft_indx]:copy()
-  -- trigger will be deleted in 'trigger_expand', compe inserts the snippet name.
-  snip.trigger = snip.name
   snip:trigger_expand(Luasnip_current_nodes[vim.api.nvim_get_current_buf()])
 end
 


### PR DESCRIPTION
Using `name` as word breaks completion displaying a lot of options.

This proposal use name and dscr to improve documentation and keep trigger as text.

![Screenshot from 2021-04-03 15-30-00](https://user-images.githubusercontent.com/40538/113489368-de8ec780-9491-11eb-857e-0c93cb1c3533.png)
