### PR TITLE
Allow sources to specify per-item priorities

### DIFF
--- a/lua/compe/source.lua
+++ b/lua/compe/source.lua
@@ -361,7 +361,9 @@ Source._normalize_items = function(self, _, items)
     -- internal properties
     item.item_id = self.item_id
     item.source_id = self.id
-    item.priority = metadata.priority or 0
+    if not item.priority then
+       item.priority = metadata.priority or 0
+    end
     item.sort = Boolean.get(metadata.sort, true)
     item.suggest_offset = item.suggest_offset or self.keyword_pattern_offset
 


### PR DESCRIPTION
This allows a source to specify the internal order of completion items
originating from this same source