### PR TITLE
Support Environment Variables in Path Completion

### DIFF
--- a/lua/compe_path/init.lua
+++ b/lua/compe_path/init.lua
@@ -66,7 +66,7 @@ Source._dirname = function(self, context)
   local prefix = string.sub(context.before_line, 1, s + 1)
 
   local buf_dirname = vim.fn.expand(('#%d:p:h'):format(context.bufnr))
-  if prefix:match('%../$') then
+  if prefix:match('%.%./$') then
     return vim.fn.resolve(buf_dirname .. '/../' .. dirname)
   elseif prefix:match('%./$') then
     return vim.fn.resolve(buf_dirname .. '/' .. dirname)

--- a/lua/compe_path/init.lua
+++ b/lua/compe_path/init.lua
@@ -72,6 +72,8 @@ Source._dirname = function(self, context)
     return vim.fn.resolve(buf_dirname .. '/' .. dirname)
   elseif prefix:match('~/$') then
     return vim.fn.expand('~/' .. dirname)
+  elseif prefix:match('%$[%a_]+/$') then
+    return vim.fn.expand(prefix:match('%$[%a_]+/$') .. dirname)
   elseif prefix:match('/$') then
     local accept = true
     -- Ignore URL components

--- a/lua/compe_path/init.lua
+++ b/lua/compe_path/init.lua
@@ -2,7 +2,7 @@ local compe = require'compe'
 
 -- TODO: ' or " or ` is valid as filename
 local NAME_PATTERN = [[\%([^/\\:\*?<>'"`\|]\)]]
-local DIRNAME_REGEX = vim.regex(([[\%(/PAT\+\)*\ze/PAT*$]]):gsub('PAT', NAME_PATTERN))
+local DIRNAME_REGEX = vim.regex(([[\%(\$PAT\+\)\?\%(/PAT\+\)*\ze/PAT*$]]):gsub('PAT', NAME_PATTERN))
 local MENU = {
   DIR = '[Dir]',
   FILE = '[File]',
@@ -72,6 +72,8 @@ Source._dirname = function(self, context)
     return vim.fn.resolve(buf_dirname .. '/' .. dirname)
   elseif prefix:match('~/$') then
     return vim.fn.expand('~/' .. dirname)
+  elseif prefix:match('^%$$') then
+    return vim.fn.expand(dirname)
   elseif prefix:match('/$') then
     local accept = true
     -- Ignore URL components

--- a/lua/compe_path/init.lua
+++ b/lua/compe_path/init.lua
@@ -2,7 +2,7 @@ local compe = require'compe'
 
 -- TODO: ' or " or ` is valid as filename
 local NAME_PATTERN = [[\%([^/\\:\*?<>'"`\|]\)]]
-local DIRNAME_REGEX = vim.regex(([[\%(\$PAT\+\)\?\%(/PAT\+\)*\ze/PAT*$]]):gsub('PAT', NAME_PATTERN))
+local DIRNAME_REGEX = vim.regex(([[\%(/PAT\+\)*\ze/PAT*$]]):gsub('PAT', NAME_PATTERN))
 local MENU = {
   DIR = '[Dir]',
   FILE = '[File]',
@@ -72,8 +72,6 @@ Source._dirname = function(self, context)
     return vim.fn.resolve(buf_dirname .. '/' .. dirname)
   elseif prefix:match('~/$') then
     return vim.fn.expand('~/' .. dirname)
-  elseif prefix:match('^%$$') then
-    return vim.fn.expand(dirname)
   elseif prefix:match('/$') then
     local accept = true
     -- Ignore URL components


### PR DESCRIPTION
Adds support for path autocompletion using environment variables such as `$HOME` and `$PWD`. Can be used in the following manner: `$PWD/tests/`.

Fixes #320, fixes #322.