### PR TITLE
Always filter using filter_text when provided

### DIFF
--- a/lua/compe/matcher.lua
+++ b/lua/compe/matcher.lua
@@ -15,9 +15,7 @@ Matcher.match = function(context, source, items)
     local word = item.original_word
     if #input > 0 then
       if item.filter_text and #item.filter_text > 0 then
-        if Character.match(string.byte(input, 1), string.byte(item.filter_text, 1)) then
-          word = item.filter_text
-        end
+        word = item.filter_text
       end
     end
 


### PR DESCRIPTION
Fix #375 

If the filtering user input didn't start with the first character of the `filter_text`, the filter text was ignored.