### PR TITLE
Fix #410: attempt to get length of local 'word' (a nil value)

### DIFF
--- a/lua/compe/matcher.lua
+++ b/lua/compe/matcher.lua
@@ -23,7 +23,7 @@ Matcher.match = function(context, source, items)
       end
     end
 
-    if #word >= #input then
+    if word ~= nil and #word >= #input then
       item.match = Matcher.analyze(input, word, item.match or {})
       item.match.exact = input == item.original_abbr
       if item.match.score >= 1 then


### PR DESCRIPTION
I'm receiving `Error executing vim.schedule lua callback: .../site/pack/packer/start/nvim-compe/lua/compe/matcher.lua:26: attempt to get length of local 'word' (a nil value)`, when editing lua files.
This should fix the issue.