### PR TITLE
Evaluate Interpolated Expressions (UltiSnips)

### DIFF
--- a/lua/compe_ultisnips/init.lua
+++ b/lua/compe_ultisnips/init.lua
@@ -25,7 +25,16 @@ local function get_snippet_preview(data, args)
         local s, e = EXPRESSION_REGEX:match_str(line)
         while s do
           local expr = string.sub(line, s+2, e-1)
-          local evaluated = vim.api.nvim_eval(expr)
+          local prefix = string.sub(expr, 1, 2)
+          local evaluated
+          if prefix == '!v' then
+            evaluated = vim.api.nvim_eval(string.sub(expr, 3))
+          elseif prefix == '!p' then
+            -- TODO: implement python interpolation (value of snip.rv)
+            evaluated = expr
+          else
+            evaluated = vim.fn.system(expr)
+          end
           line = string.sub(line, 1, s+1) .. evaluated .. string.sub(line, e+1)
           s, e = EXPRESSION_REGEX:match_str(line)
         end

--- a/lua/compe_ultisnips/init.lua
+++ b/lua/compe_ultisnips/init.lua
@@ -39,6 +39,7 @@ local function get_snippet_preview(data, args)
               evaluated = expr
             else
               evaluated = vim.fn.system(expr)
+              evaluated = string.gsub(evaluated, "\n$", "")
             end
             line = string.sub(line, 1, s) .. evaluated .. string.sub(line, e+1)
             start_i = s + #evaluated + 1

--- a/lua/compe_ultisnips/init.lua
+++ b/lua/compe_ultisnips/init.lua
@@ -1,5 +1,8 @@
 local compe = require'compe'
 
+-- matches any text within backticks, skipping over escaped ones
+local EXPRESSION_REGEX = vim.regex([[`\(\\`\|[^`]\)\+`]])
+
 local M = {}
 
 local function get_snippet_preview(data, args)
@@ -19,6 +22,13 @@ local function get_snippet_preview(data, args)
         break
       end
       if not is_snippet_header then
+        local s, e = EXPRESSION_REGEX:match_str(line)
+        while s do
+          local expr = string.sub(line, s+2, e-1)
+          local evaluated = vim.api.nvim_eval(expr)
+          line = string.sub(line, 1, s+1) .. evaluated .. string.sub(line, e+1)
+          s, e = EXPRESSION_REGEX:match_str(line)
+        end
         table.insert(snippet, line)
       end
     end


### PR DESCRIPTION
UltiSnips supports interpolated expressions as documented [here](https://github.com/SirVer/ultisnips/blob/master/doc/UltiSnips.txt#L820-L1069). This PR evaluates these expressions for the documentation preview of the snippet. Shell code and Vimscript expressions are implemented, but not Python code as it is much more involved and I'm not sure how to approach it.

Example:
With the snippet:
```
snippet date
`date "+%d-%m-%Y"`
endsnippet
```

Current behavior:
![DeepinScreenshot_select-area_20210614222456](https://user-images.githubusercontent.com/19642235/121983620-9cbab100-cd5f-11eb-8fa2-eaa9bdbebfae.png)

New behavior:
![DeepinScreenshot_select-area_20210614222407](https://user-images.githubusercontent.com/19642235/121983638-a3492880-cd5f-11eb-8ac9-2da72713e7b9.png)


Fixes #384.