### PR TITLE
fix default throttle time

### DIFF
--- a/lua/compe/config.lua
+++ b/lua/compe/config.lua
@@ -1,7 +1,7 @@
 local Boolean = require'compe.utils.boolean'
 local Lazy = require'compe.lazy'
 
-local THROTTLE_TIME = 120
+local THROTTLE_TIME = 80
 local SOURCE_TIMEOUT = 200
 local RESOLVE_TIMEOUT = 800
 local INCOMPLETE_DELAY = 400


### PR DESCRIPTION
I've noticed that [the docs](https://github.com/hrsh7th/nvim-compe/blob/master/doc/compe.txt#L257-L260) and the [README](https://github.com/hrsh7th/nvim-compe/blob/master/README.md) say that throttle time defaults to 80 but [the code](https://github.com/hrsh7th/nvim-compe/blob/master/lua/compe/config.lua#L4) says otherwise. This is a fix for that.