### PR TITLE
Fixes #432

### DIFF
--- a/autoload/compe/documentation.vim
+++ b/autoload/compe/documentation.vim
@@ -54,6 +54,7 @@ function! compe#documentation#open(text) abort
   endif
 
   silent call s:window.open({
+  \   'relative': 'win',
   \   'row': l:pos[0] + 1,
   \   'col': l:pos[1] + 1,
   \   'width': l:state.size.width,

--- a/autoload/vital/_compe/VS/Vim/Window/FloatingWindow.vim
+++ b/autoload/vital/_compe/VS/Vim/Window/FloatingWindow.vim
@@ -213,6 +213,10 @@ function! s:FloatingWindow.open(args) abort
   \   'origin': get(a:args, 'origin', 'topleft'),
   \ }
 
+  if has('nvim')
+    l:style.relative = get(a:args, 'relative', 'editor)
+  endif
+
   let l:will_move = self.is_visible()
   if l:will_move
     let self._winid = s:_move(self, self._winid, self._bufnr, l:style)
@@ -376,7 +380,7 @@ if has('nvim')
     let l:style = s:_resolve_origin(a:style)
     let l:style = s:_resolve_border(l:style)
     let l:style = {
-    \   'relative': 'editor',
+    \   'relative': has_key(l:style, 'relative') ? l:style.relative : 'editor',
     \   'row': l:style.row - 1,
     \   'col': l:style.col - 1,
     \   'width': l:style.width,

--- a/autoload/vital/_compe/VS/Vim/Window/FloatingWindow.vim
+++ b/autoload/vital/_compe/VS/Vim/Window/FloatingWindow.vim
@@ -214,7 +214,7 @@ function! s:FloatingWindow.open(args) abort
   \ }
 
   if has('nvim')
-    l:style.relative = get(a:args, 'relative', 'editor')
+    let l:style.relative = get(a:args, 'relative', 'editor')
   endif
 
   let l:will_move = self.is_visible()

--- a/autoload/vital/_compe/VS/Vim/Window/FloatingWindow.vim
+++ b/autoload/vital/_compe/VS/Vim/Window/FloatingWindow.vim
@@ -214,7 +214,7 @@ function! s:FloatingWindow.open(args) abort
   \ }
 
   if has('nvim')
-    l:style.relative = get(a:args, 'relative', 'editor)
+    l:style.relative = get(a:args, 'relative', 'editor')
   endif
 
   let l:will_move = self.is_visible()


### PR DESCRIPTION
Fixes https://github.com/hrsh7th/nvim-compe/issues/432 by modifying the floating window utility functions to use relative "win" rather than relative "editor". This is because in multigrid environments the position of the documentation window was incorrect as explained in the issue.