### PR TITLE
Make spell completion respect vim spell option

### DIFF
--- a/lua/compe_spell/init.lua
+++ b/lua/compe_spell/init.lua
@@ -14,10 +14,10 @@ function Source.get_metadata(_)
 end
 
 function Source.determine(_, context)
-  if vim.wo.spell == 0 then
-    return {}
+  if vim.wo.spell then
+    return compe.helper.determine(context)
   end
-  return compe.helper.determine(context)
+  return {}
 end
 
 function Source.complete(_, context)


### PR DESCRIPTION
This makes spell completion respect `set nospell`.

The current conditional `vim.wo.spell == 0` will always return false.