### PR TITLE
ref(README): simplify `check_back_space`

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,11 +310,7 @@ end
 
 local check_back_space = function()
     local col = vim.fn.col('.') - 1
-    if col == 0 or vim.fn.getline('.'):sub(col, col):match('%s') then
-        return true
-    else
-        return false
-    end
+    return col == 0 or vim.fn.getline('.'):sub(col, col):match('%s') ~= nil
 end
 
 -- Use (s-)tab to:


### PR DESCRIPTION
For this function, using an `if` statement to `return` a boolean value is the same as just returning that value directly. The one caveat is that `:match` doesn't return a bool value, so we have to convert it into a boolean value by testing for `~= nil`.