### PR TITLE
Added more documentation info for tags

### DIFF
--- a/lua/compe_tags/init.lua
+++ b/lua/compe_tags/init.lua
@@ -40,20 +40,21 @@ function Source.documentation(_, context)
       break
     end
     local doc =  tag.filename .. ' [' .. tag.kind .. ']'
-    if #tag.cmd >= 5 then
-        doc = doc .. '\n  ' .. tag.cmd:sub(3, -3):gsub('%s+', ' ')
+        local doc =  '# ' .. tag.filename .. ' [' .. tag.kind .. ']'
+    if #tag.cmd >= 5 and tag.signature == nil then
+        doc = doc .. '\n  __' .. tag.cmd:sub(3, -3):gsub('%s+', ' ') .. '__'
     end
     if tag.access ~= nil then
         doc = doc .. '\n  ' .. tag.access
     end
     if tag.implementation ~= nil then
-        doc = doc .. '\n  ' .. tag.implementation
+        doc = doc .. '\n  impl: _' .. tag.implementation .. '_'
     end
     if tag.inherits ~= nil then
         doc = doc .. '\n  ' .. tag.inherits
     end
     if tag.signature ~= nil then
-        doc = doc .. '\n  ' .. tag.signature
+        doc = doc .. '\n  sign: _' .. tag.name .. tag.signature .. '_'
     end
     if tag.scope ~= nil then
         doc = doc .. '\n  ' .. tag.scope
@@ -67,6 +68,8 @@ function Source.documentation(_, context)
     if tag.enum ~= nil then
         doc = doc .. '\n  in ' .. tag.enum
     end
+    table.insert(document, doc)
+
     table.insert(document, doc)
   end
 

--- a/lua/compe_tags/init.lua
+++ b/lua/compe_tags/init.lua
@@ -39,7 +39,35 @@ function Source.documentation(_, context)
       table.insert(document, ('...and %d more'):format(#tags - 10))
       break
     end
-    table.insert(document, tag.filename)
+    local doc =  tag.filename .. ' [' .. tag.kind .. ']'
+    if #tag.cmd >= 5 then
+        doc = doc .. '\n  ' .. tag.cmd:sub(3, -4):gsub('%s+', ' ')
+    end
+    if tag.access ~= nil then
+        doc = doc .. '\n  ' .. tag.access
+    end
+    if tag.implementation ~= nil then
+        doc = doc .. '\n  ' .. tag.implementation
+    end
+    if tag.inherits ~= nil then
+        doc = doc .. '\n  ' .. tag.inherits
+    end
+    if tag.signature ~= nil then
+        doc = doc .. '\n  ' .. tag.signature
+    end
+    if tag.scope ~= nil then
+        doc = doc .. '\n  ' .. tag.scope
+    end
+    if tag.struct ~= nil then
+        doc = doc .. '\n  in ' .. tag.struct
+    end
+    if tag.class ~= nil then
+        doc = doc .. '\n  in ' .. tag.class
+    end
+    if tag.enum ~= nil then
+        doc = doc .. '\n  in ' .. tag.enum
+    end
+    table.insert(document, doc)
   end
 
   context.callback(document)

--- a/lua/compe_tags/init.lua
+++ b/lua/compe_tags/init.lua
@@ -41,7 +41,7 @@ function Source.documentation(_, context)
     end
     local doc =  tag.filename .. ' [' .. tag.kind .. ']'
     if #tag.cmd >= 5 then
-        doc = doc .. '\n  ' .. tag.cmd:sub(3, -4):gsub('%s+', ' ')
+        doc = doc .. '\n  ' .. tag.cmd:sub(3, -3):gsub('%s+', ' ')
     end
     if tag.access ~= nil then
         doc = doc .. '\n  ' .. tag.access


### PR DESCRIPTION
Actually, I would like to put `tag.kind` in the `menu` entry near the `[T]` symbol (e.g. `f [T]` as a symbol for a function would be nice. I don't know how to achieve that, though...

Other things that could be added is the context from the file around the specific line, if the line is available; it could substitute the exe cmd used to find the tag