### PR TITLE
ref(README): call `vsnip#` functions directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ end
 _G.tab_complete = function()
   if vim.fn.pumvisible() == 1 then
     return t "<C-n>"
-  elseif vim.fn.call("vsnip#available", {1}) == 1 then
+  elseif vim.fn['vsnip#available'](1) == 1 then
     return t "<Plug>(vsnip-expand-or-jump)"
   elseif check_back_space() then
     return t "<Tab>"
@@ -334,7 +334,7 @@ end
 _G.s_tab_complete = function()
   if vim.fn.pumvisible() == 1 then
     return t "<C-p>"
-  elseif vim.fn.call("vsnip#jumpable", {-1}) == 1 then
+  elseif vim.fn['vsnip#jumpable'](-1) == 1 then
     return t "<Plug>(vsnip-jump-prev)"
   else
     -- If <S-Tab> is not working in your terminal, change it to <C-h>


### PR DESCRIPTION
Previously, there was a `vim.fn.call` invocation which was used to call vsnip autoload functions (assumedly, because they use the special `#` syntax). However, this can be done with `vim.fn['vsnip#foo']` directly.