### PR TITLE
fix(documentation): make a copy of the completion result to prevent double escaping of plaintext

### DIFF
--- a/lua/compe_nvim_lsp/source.lua
+++ b/lua/compe_nvim_lsp/source.lua
@@ -101,6 +101,9 @@ function Source._create_document(self, filetype, completion_item)
   if type(doc) == "string" then
     doc = string.format("```%s\n%s\n```", filetype, doc)
   end
+  -- HACK: make a deepcopy to prevent double escaping of plaintext
+  -- see also https://github.com/hrsh7th/nvim-compe/issues/440
+  doc = vim.tbl_deep_extend("force", {}, doc)
   return doc and util.convert_input_to_markdown_lines(doc) or {}
 end
 


### PR DESCRIPTION
This PR fixes #440

I also pushed a fix upstream to fix this https://github.com/neovim/neovim/pull/14989

But this PR will also fix it for people using 0.5