### PR TITLE
fix: don't render blank lines at the bottom

### DIFF
--- a/lua/compe/float.lua
+++ b/lua/compe/float.lua
@@ -103,16 +103,14 @@ function M.show(contents, opts)
 
   local buf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
+
+  -- applies the syntax and sets the lines to the buffer
   contents = vim.lsp.util.stylize_markdown(buf, contents, opts)
 
   local float_options = M.get_options(contents, opts)
   if not float_options then
     return
   end
-
-  -- applies the syntax and sets the lines to the buffer
-  opts.width = float_options.width or opts.width
-  opts.height = float_options.height or opts.height
 
   -- reuse existing window, or create a new one
   if M.win and vim.api.nvim_win_is_valid(M.win) then

--- a/lua/compe/float.lua
+++ b/lua/compe/float.lua
@@ -96,20 +96,20 @@ function M.show(contents, opts)
   -- Clean up input: trim empty lines from the end, pad
   contents = vim.lsp.util._trim(contents, opts)
 
-  local float_options = M.get_options(contents, opts)
-
   -- close if nothing to display
-  if not float_options or #contents == 0 then
+  if #contents == 0 then
     return M.close()
   end
 
   local buf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
+  contents = vim.lsp.util.stylize_markdown(buf, contents, opts)
+
+  local float_options = M.get_options(contents, opts)
 
   -- applies the syntax and sets the lines to the buffer
   opts.width = float_options.width or opts.width
   opts.height = float_options.height or opts.height
-  contents = vim.lsp.util.stylize_markdown(buf, contents, opts)
 
   -- reuse existing window, or create a new one
   if M.win and vim.api.nvim_win_is_valid(M.win) then

--- a/lua/compe/float.lua
+++ b/lua/compe/float.lua
@@ -106,6 +106,9 @@ function M.show(contents, opts)
   contents = vim.lsp.util.stylize_markdown(buf, contents, opts)
 
   local float_options = M.get_options(contents, opts)
+  if not float_options then
+    return
+  end
 
   -- applies the syntax and sets the lines to the buffer
   opts.width = float_options.width or opts.width

--- a/lua/compe/float.lua
+++ b/lua/compe/float.lua
@@ -69,7 +69,7 @@ function M.scroll(delta)
     local top = info.topline or 1
     top = top + delta
     top = math.max(top, 1)
-    top = math.min(top, vim.api.nvim_buf_line_count(buf))
+    top = math.min(top, vim.api.nvim_buf_line_count(buf) - info.height + 1)
 
     vim.defer_fn(function()
       vim.api.nvim_buf_call(buf, function()


### PR DESCRIPTION
It turns out that the height of the doc window is the number of lines
in the text. The problem here is that each code blocks contain two extra
lines which will be removed by `stylize_markdown` function and thus the
extra space.

The problem does not seem to appear in any of the LSP floating window
because of the order the functions are being invoked. `stylize_markdown`
needs to be invoked first which will remove those code fences and apply
the syntax highlighting and then we should be calculating the height of
the floating window.

Fixes: #456 

cc @folke Could you take a look at this as this is your forte :)

_Before:_
<img width="1251" alt="Screenshot 2021-07-08 at 22 47 07" src="https://user-images.githubusercontent.com/67177269/124964882-27c95700-e03f-11eb-8649-4a40064e2bcd.png">

_After:_
<img width="1134" alt="Screenshot 2021-07-08 at 22 47 39" src="https://user-images.githubusercontent.com/67177269/124964910-2d26a180-e03f-11eb-9fc3-a0cb6753eb94.png">
