### PR TITLE
Fix regression with showing empty resolve window

### DIFF
--- a/lua/compe_nvim_lsp/source.lua
+++ b/lua/compe_nvim_lsp/source.lua
@@ -101,7 +101,7 @@ end
 --- _create_document
 function Source._create_document(_, filetype, completion_item)
   local detail = (function()
-    if completion_item.detail then
+    if completion_item.detail and completion_item.detail ~= '' then
       return string.format("```%s\n%s\n```", filetype, completion_item.detail)
     end
   end)()


### PR DESCRIPTION
I actually fixed this in the past already here:
https://github.com/hrsh7th/nvim-compe/commit/4df0108195dfbc36f6143a7d0e1f6bf6418432b8,
but it looks like is snuck back in. Some servers will still return a
`detail` field in the completion item with an empty string. Currently
this is causing an extra empty window to appear. This small change just
makes sure the detail isn't empty, and if it is, don't show the window.

Before:

<img width="282" alt="Screenshot 2021-07-10 at 11 21 38" src="https://user-images.githubusercontent.com/13974112/125158438-7d058580-e171-11eb-8795-ab93d6d688ab.png">

After:
<img width="282" alt="Screenshot 2021-07-10 at 11 24 55" src="https://user-images.githubusercontent.com/13974112/125158442-8131a300-e171-11eb-82ba-84fb15f7ac8d.png">
