### PR TITLE
use `textEdit.newText` whenever `textEdit` is provided

### DIFF
--- a/lua/compe/helper.lua
+++ b/lua/compe/helper.lua
@@ -83,7 +83,11 @@ Helper.convert_lsp = function(args)
       end
       word = text
     else
-      word = insert_text or completion_item.label
+      if completion_item.textEdit ~= nil and completion_item.textEdit.newText ~= nil then
+        word = completion_item.textEdit.newText
+      else
+        word = insert_text or completion_item.label
+      end
       abbr = completion_item.label
     end
     word = String.trim(word)


### PR DESCRIPTION
According to the LSP spec, `insertText` should be ignored when `textEdit` is provided.

https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#completionItem

The current implementation causes a bug for the Metals (Scala) language server, which provides `textEdit` instead of `insertText` for completion items. 

