### PR TITLE
Fixes #400

### DIFF
--- a/lua/compe/source.lua
+++ b/lua/compe/source.lua
@@ -149,6 +149,7 @@ Source.trigger = function(self, context, callback)
 
     -- Completion
     self.source:complete({
+      metadata = self.metadata;
       context = self.context;
       input = self.context:get_input(state.keyword_pattern_offset);
       keyword_pattern_offset = state.keyword_pattern_offset;

--- a/lua/compe_ultisnips/init.lua
+++ b/lua/compe_ultisnips/init.lua
@@ -51,12 +51,16 @@ function M:complete(args)
   local snippets_list = vim.g.current_ulti_dict_info
 
   local completion_list = {}
+  local kind = 'Snippet'
+  if args.metadata.kind ~= nil then
+     kind = args.metadata.kind
+  end
   for key, value in pairs(snippets_list) do
     local item = {
       word =  key,
       abbr =  key,
       user_data = value,
-      kind = 'Snippet',
+      kind = kind,
       dup = 1
     }
     table.insert(completion_list, item)


### PR DESCRIPTION
Fixed by passing the metadata as one of the arguments to the 'source.complete' function. Then, check if 'kind' is set in the metadata. The default is still 'Snippet'.



