### PR TITLE
stale: Disable on pull requests

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -41,7 +41,7 @@ markComment: >
 limitPerRun: 30
 
 # Limit to only `issues` or `pulls`
-# only: issues
+only: issues
 
 # Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
 # pulls:


### PR DESCRIPTION
I dislike bots like this generally, but I especially think it's
disheartening to auto-reject PRs. I'd think more than twice
about contributing to a project if I thought my contribution
would eventually be closed by a bot. For an example, see
  https://github.com/hrsh7th/nvim-compe/pull/378#issuecomment-898434903