### PR TITLE
allow hidden buffers in completion with option

### DIFF
--- a/lua/compe/config.lua
+++ b/lua/compe/config.lua
@@ -70,6 +70,7 @@ Config._normalize = function(config)
   config.max_abbr_width = config.max_abbr_width or 100
   config.max_kind_width = config.max_kind_width or 100
   config.max_menu_width = config.max_menu_width or 100
+  config.allow_hidden_buffers = config.allow_hidden_buffers or false
   config.autocomplete = Boolean.get(config.autocomplete, true)
 
   local documentation_defaults = {

--- a/lua/compe_buffer/init.lua
+++ b/lua/compe_buffer/init.lua
@@ -1,5 +1,6 @@
 local compe = require'compe'
 local Buffer = require'compe_buffer.buffer'
+local Config = require'compe.config'
 
 local Source = {
   buffers = {};
@@ -64,8 +65,17 @@ end
 --- _get_bufs
 function Source._get_buffers(self)
   local bufs = {}
-  for _, win in ipairs(vim.api.nvim_list_wins()) do
-    bufs[vim.api.nvim_win_get_buf(win)] = true
+  local config = Config.get()
+
+  if config.allow_hidden_buffers then
+
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      bufs[buf] = true
+    end
+  else
+    for _, win in ipairs(vim.api.nvim_list_wins()) do
+      bufs[vim.api.nvim_win_get_buf(win)] = true
+    end
   end
 
   local buffers = {}


### PR DESCRIPTION
This allows completion of words from buffers that aren't currently open if allowed in the configuration.

TODO:
- [ ] ill need some help in determining the best way to insert this configuration option. There didn't seem like a good method for setting options at the source level, so I had to create a global option.
- [ ] update documentation