### PR TITLE
Fix broken Luasnip integration

### DIFF
--- a/lua/compe_luasnip/init.lua
+++ b/lua/compe_luasnip/init.lua
@@ -62,7 +62,7 @@ end
 function Source.confirm(_, context)
   local item = context.completed_item
   local snip = luasnip.snippets[item.kind][item.user_data.ft_indx]:copy()
-  snip:trigger_expand(Luasnip_current_nodes[vim.api.nvim_get_current_buf()])
+  snip:trigger_expand(luasnip.session.current_nodes[vim.api.nvim_get_current_buf()])
 end
 
 return Source.new()


### PR DESCRIPTION
In this change https://github.com/L3MON4D3/LuaSnip/commit/a1580b62beaffad0d631219d1b14764b17ab63aa
LuaSnip removed global table `Luasnip_current_nodes`
which now needs to be accessed as `luasnip.session.current_nodes`